### PR TITLE
Add close settings to local graph synchronization

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -121,8 +121,9 @@ export default class SyncGraphPlugin extends Plugin {
 		const graphConfig = JSON.parse(graphConfigJson);
 		const graphColorGroups = graphConfig.colorGroups;
 		const searchFilters = graphConfig.search;
+		const closeSettings = graphConfig.close;
 		this.getLocalGraphLeaves().forEach((leaf) => {
-			this.setSettings(leaf, graphColorGroups, searchFilters);
+			this.setSettings(leaf, graphColorGroups, searchFilters, closeSettings);
 		})
 	}
 
@@ -130,10 +131,11 @@ export default class SyncGraphPlugin extends Plugin {
 		return this.app.workspace.getLeavesOfType('localgraph');
 	}
 
-	setSettings(localGraphLeaf: WorkspaceLeaf, colorGroups: any, searchFilters: any) {
+	setSettings(localGraphLeaf: WorkspaceLeaf, colorGroups: any, searchFilters: any, closeSettings: any) {
 		const viewState = localGraphLeaf.getViewState();
 		viewState.state.options.colorGroups = colorGroups;
 		viewState.state.options.search = searchFilters;
+		viewState.state.options.close = closeSettings;
 
 		viewState.state.options.localJumps = this.settings.defaultDepth;
 		viewState.state.options.localBacklinks = this.settings.defaultIncomingLinks;


### PR DESCRIPTION
- Import closeSettings from global graph configuration
- Pass closeSettings to setSettings function
- Apply closeSettings to local graph view state

This change ensures that the close settings from the global graph are also synchronized to the local graph, providing a more consistent experience across graph views.